### PR TITLE
Palo Alto Wildfire plugin

### DIFF
--- a/Scripts/PIE_Message-Trace-Logging/Invoke-O365Trace.ps1
+++ b/Scripts/PIE_Message-Trace-Logging/Invoke-O365Trace.ps1
@@ -878,18 +878,20 @@ Case Folder:                 $caseID
         # SHODAN
         if ( $shodan -eq $true ) {
 
-            echo "Shodan.io" >> "$caseFolder$caseID\spam-report.txt"
-            echo "============================================================" >> "$caseFolder$caseID\spam-report.txt"
+            if ( $domains.length -gt 0 ) {
+                echo "Shodan.io" >> "$caseFolder$caseID\spam-report.txt"
+                echo "============================================================" >> "$caseFolder$caseID\spam-report.txt"
 
-            $domains | ForEach-Object {
-                echo "Shodan Analysis: $_" >> "$caseFolder$caseID\spam-report.txt"
+                $domains | ForEach-Object {
+                    echo "Shodan Analysis: $_" >> "$caseFolder$caseID\spam-report.txt"
 
-                & $pieFolder\plugins\Shodan.ps1 -key $shodanAPI -link $_ -caseID $caseID -caseFolder "$caseFolder" -pieFolder "$pieFolder" -logRhythmHost $logRhythmHost -caseAPItoken $caseAPItoken
+                    & $pieFolder\plugins\Shodan.ps1 -key $shodanAPI -link $_ -caseID $caseID -caseFolder "$caseFolder" -pieFolder "$pieFolder" -logRhythmHost $logRhythmHost -caseAPItoken $caseAPItoken
             
-            }
+                }
 
-            echo "============================================================" >> "$caseFolder$caseID\spam-report.txt"
-            echo "" >> "$caseFolder$caseID\spam-report.txt"
+                echo "============================================================" >> "$caseFolder$caseID\spam-report.txt"
+                echo "" >> "$caseFolder$caseID\spam-report.txt"
+            }
         }
 
         # OPEN DNS
@@ -1041,23 +1043,26 @@ Case Folder:                 $caseID
         # Wildfire
         if ( $wildfire -eq $true ) {
 
-            echo "Palo Alto Wildfire" >> "$caseFolder$caseID\spam-report.txt"
-            echo "============================================================" >> "$caseFolder$caseID\spam-report.txt"
-            echo "" >> "$caseFolder$caseID\spam-report.txt"
+            if ( $fileHashes.Length -gt 0 ) {
 
-            $fileHashes | ForEach-Object {
-
-                $wfFName = Split-Path -Path $($_.path) -Leaf
-                echo "" >> "$caseFolder$caseID\spam-report.txt"
-                echo "Wildfire Analysis: File: $caseFolder$caseID\attachments\$wfFName Hash: $($_.hash)" >> "$caseFolder$caseID\spam-report.txt"
-                & $pieFolder\plugins\Wildfire.ps1 -key $wildfireAPI -fileHash $($_.hash) -fileName $wfFName -caseID $caseID -caseFolder "$caseFolder" -pieFolder "$pieFolder" -logRhythmHost $logRhythmHost -caseAPItoken $caseAPItoken
+                echo "Palo Alto Wildfire" >> "$caseFolder$caseID\spam-report.txt"
+                echo "============================================================" >> "$caseFolder$caseID\spam-report.txt"
                 echo "" >> "$caseFolder$caseID\spam-report.txt"
 
+                $fileHashes | ForEach-Object {
+
+                    $wfFName = Split-Path -Path $($_.path) -Leaf
+                    echo "" >> "$caseFolder$caseID\spam-report.txt"
+                    echo "Wildfire Analysis: File: $caseFolder$caseID\attachments\$wfFName Hash: $($_.hash)" >> "$caseFolder$caseID\spam-report.txt"
+                    & $pieFolder\plugins\Wildfire.ps1 -key $wildfireAPI -fileHash $($_.hash) -fileName $wfFName -caseID $caseID -caseFolder "$caseFolder" -pieFolder "$pieFolder" -logRhythmHost $logRhythmHost -caseAPItoken $caseAPItoken
+                    echo "" >> "$caseFolder$caseID\spam-report.txt"
+
+                }
+
+                echo "" >> "$caseFolder$caseID\spam-report.txt"
+                echo "============================================================" >> "$caseFolder$caseID\spam-report.txt"
+                echo "" >> "$caseFolder$caseID\spam-report.txt"
             }
-
-            echo "" >> "$caseFolder$caseID\spam-report.txt"
-            echo "============================================================" >> "$caseFolder$caseID\spam-report.txt"
-            echo "" >> "$caseFolder$caseID\spam-report.txt"
         }
 
 

--- a/Scripts/PIE_Message-Trace-Logging/Invoke-O365Trace.ps1
+++ b/Scripts/PIE_Message-Trace-Logging/Invoke-O365Trace.ps1
@@ -142,6 +142,10 @@ $screenshotKey = ""
 $threatGrid = $false
 $threatGridAPI = ""
 
+# Palo Alto Wildfire
+$wildfire = $false
+$wildfireAPI = ""
+
 # Wrike
 $wrike = $false
 $wrikeAPI = ""
@@ -513,6 +517,7 @@ if ( $log -eq $true) {
                 $a = $_.filename 
                 If (-Not ($a -match $boringFilesRegex)) { 
                     $_.saveasfile((Join-Path $tmpFolder $a)) 
+                    $fileHashes += @(Get-FileHash $tmpFolder$a -Algorithm SHA256)
                 }
             }
             $attachmentFull = "$caseFolder$caseID\attachments\" + $a
@@ -1032,6 +1037,29 @@ Case Folder:                 $caseID
                 & $pieFolder\plugins\Case-API.ps1 -lrhost $LogRhythmHost -casenum $caseNumber -updateCase "VirusTotal API key required to check / submit samples" -token $caseAPItoken
             }
         }
+
+        # Wildfire
+        if ( $wildfire -eq $true ) {
+
+            echo "Palo Alto Wildfire" >> "$caseFolder$caseID\spam-report.txt"
+            echo "============================================================" >> "$caseFolder$caseID\spam-report.txt"
+            echo "" >> "$caseFolder$caseID\spam-report.txt"
+
+            $fileHashes | ForEach-Object {
+
+                $wfFName = Split-Path -Path $($_.path) -Leaf
+                echo "" >> "$caseFolder$caseID\spam-report.txt"
+                echo "Wildfire Analysis: File: $caseFolder$caseID\attachments\$wfFName Hash: $($_.hash)" >> "$caseFolder$caseID\spam-report.txt"
+                & $pieFolder\plugins\Wildfire.ps1 -key $wildfireAPI -fileHash $($_.hash) -fileName $wfFName -caseID $caseID -caseFolder "$caseFolder" -pieFolder "$pieFolder" -logRhythmHost $logRhythmHost -caseAPItoken $caseAPItoken
+                echo "" >> "$caseFolder$caseID\spam-report.txt"
+
+            }
+
+            echo "" >> "$caseFolder$caseID\spam-report.txt"
+            echo "============================================================" >> "$caseFolder$caseID\spam-report.txt"
+            echo "" >> "$caseFolder$caseID\spam-report.txt"
+        }
+
 
         # SHORT LINK ANALYSIS
         if ( $shortLink -eq $true ) {

--- a/Scripts/PIE_Message-Trace-Logging/plugins/Wildfire.ps1
+++ b/Scripts/PIE_Message-Trace-Logging/plugins/Wildfire.ps1
@@ -1,6 +1,6 @@
 #====================================#
 #       Wildfire PIE plugin          #
-#         Version 0.2                #
+#         Version 0.4                #
 #        Author: Jtekt               #
 #====================================#
 #
@@ -9,19 +9,22 @@
 # Early development of Wildfire integration for PIE. 
 #   
 # Goals:
-# <In Progress> - Send MD5 or SHA256 hash to Wildfire API for results.  If results show malicious, return details.
-# <In Progress> - Send bulk MD5 or SHA256 - Will reduce number of API calls to support large installations.
+# <Complete> - Send MD5 or SHA256 hash to Wildfire API for results.  If results show malicious, return details.
+# <Complete> - PIE reporting.
+#
+# 
+# <Not Started> - Send bulk MD5 or SHA256 - Will reduce number of API calls to support large installations.
 # <Not Started> - URL inspection.
-# <Not Started> - PIE ingestion.
+# 
 #
 
-# .\Wildfire.ps1 -key $wildfireAPI -checkLink $link -checkFile $file|$hash -caseID $caseID -caseFolder $caseFolder -pieFolder $pieFolder -logRhythmHost $logRhythmHost -caseAPItoken $caseAPItoken
+# .\Wildfire.ps1 -key $wildfireAPI -fileHash $fileHash -fileName $fileName -caseID $caseID -caseFolder $caseFolder -pieFolder $pieFolder -logRhythmHost $logRhythmHost -caseAPItoken $caseAPItoken
 
 [CmdLetBinding()]
 param( 
     [string]$key,
-    [string]$checkLink,
-    [string]$checkFile,
+    [string]$fileHash,
+    [string]$fileName,
     [string]$caseID,
     [string]$caseFolder,
     [string]$pieFolder,
@@ -29,15 +32,10 @@ param(
     [string]$caseAPItoken
 )
 #Temp Variables
-$key = ''
-#$hash = "dca86121cc7427e375fd24fe5871d727"
-#$checkFile = "C:\hashlist.txt"
-$checkLink = "http://paloaltonetworks.com"
+$key = Get-Content D:\nCloud\Projects\git\wildfire\key.txt
 $tmpFolder = ".\"
-#if ( !$hash -eq $true ) {
-#    $temp_hash = Get-FileHash $file -Algorithm SHA256
-#    $hash = $temp_hash.hash
-#}
+$fileName = "myworkbook.xls"
+$fileHash = "dca86121cc7427e375fd24fe5871d727"
 
 
 # Mask errors
@@ -46,10 +44,16 @@ $ErrorActionPreference= 'continue'
 
 # Global Parameters
 $IPregex='(?<Address>((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))'
+#Future use, validators
+$MD5regex='(?<Hash>([a-f0-9]{32}))'
+$SHA256regex='(?<Hash>([A-Fa-f0-9]{64}))'
 
-if ( $checkFile ) {
+#Hash validation
+
+
+if ( $fileHash ) {
     #Get verdict - single lookup - Simple lookup
-    [xml]$wfQuery = Invoke-WebRequest -uri "https://wildfire.paloaltonetworks.com/publicapi/get/verdict" -Method Post -Body "apikey=$key;hash=$hash;format=xml"
+    [xml]$wfQuery = Invoke-WebRequest -uri "https://wildfire.paloaltonetworks.com/publicapi/get/verdict" -Method Post -Body "apikey=$key;hash=$fileHash;format=xml"
     $wfVerdict = $wfQuery.wildfire.'get-verdict-info'.verdict
     Write-Host $wfVerdict
     switch ( $wfVerdict )
@@ -68,11 +72,19 @@ if ( $checkFile ) {
         }
         -100{
             #-100 Hash is currently pending
-            WRite-Host "Submitted hash value is currently pending evaluation."
+            Write-Host "Submitted hash value is currently pending evaluation."
+            echo "Palo Alto Wildfire Results" >> "$caseFolder$caseID\spam-report.txt"
+            echo "Submitted file: $fileName" >> "$caseFolder$caseID\spam-report.txt"
+            echo "Submitted hash: $fileHash" >> "$caseFolder$caseID\spam-report.txt"
+            echo "Wildfire Verdict: Status Pending" >> "$caseFolder$caseID\spam-report.txt"
         }
         0{
             #0 FIle identified as bening
             Write-Host "Submitted hash value is confirmed bening."
+            echo "Palo Alto Wildfire Results" >> "$caseFolder$caseID\spam-report.txt"
+            echo "Submitted file: $fileName" >> "$caseFolder$caseID\spam-report.txt"
+            echo "Submitted hash: $fileHash" >> "$caseFolder$caseID\spam-report.txt"
+            echo "Wildfire Verdict: File Bening" >> "$caseFolder$caseID\spam-report.txt"
         }
         1{
             #1 File identified as malware
@@ -88,126 +100,26 @@ if ( $checkFile ) {
         }
     }
     if ( $wfVerdict -eq "1" -or $wfVerdict -eq "2" ) {
-        [xml]$wfQuery = Invoke-WebRequest -uri "https://wildfire.paloaltonetworks.com/publicapi/get/report" -Method Post -Body "apikey=$key;hash=$hash;format=xml"
-        #$wfQuery.RawContent | Out-File $tmpFolder\wfAnalysis.txt
-        #[xml]$wfResults = Get-Content $tmpFolder\wfAnalysis.txt | select -Skip 7
-        #### Are there results?!####
-        ## If yes, proceed to evaluate
-        ## If no, upload file
-        #Write-Host "====================================="
-        $wfMalware = $wfQuery.wildfire.file_info.malware
-        $wfFiletype = $wfQuery.wildfire.file_info.filetype
-        $wfFileMd5 = $wfQuery.wildfire.file_info.md5
-        $wfFileSha256 = $wfQuery.wildfire.file_info.sha256
-        $wfFileSize = $wfQuery.wildfire.file_info.size
-        Write-Host "Wildfire record for $hash.  Is it malware: $wfMalware File Type: $wfFiletype File Size: $wfFileSize MD5: $wfFileMd5  SHA256: $wfFileSha256"
+        [xml]$wfReport = Invoke-WebRequest -uri "https://wildfire.paloaltonetworks.com/publicapi/get/report" -Method Post -Body "apikey=$key;hash=$fileHash;format=xml"
+        $wfMalware = $wfReport.wildfire.file_info.malware
+        $wfFiletype = $wfReport.wildfire.file_info.filetype
+        $wfFileMd5 = $wfReport.wildfire.file_info.md5
+        $wfFileSha256 = $wfReport.wildfire.file_info.sha256
+        $wfFileSize = $wfReport.wildfire.file_info.size
+        $wfStatus = "MALICIOUS FILE DETECTED! Wildfire has reported $fileName as Malware.\r\nWildfire Information:\r\n File Type: $wfFiletype\r\n File MD5: $wfFileMd5\r\n File SHA256: $wfFileSha256\r\n File Size: $wfFileSize"
+        Write-Host $wfStatus
+        $threatScore += 1
+
+        #& $pieFolder\plugins\Case-API.ps1 -lrhost $LogRhythmHost -casenum $caseNumber -updateCase "$wfStatus" -token $caseAPItoken
         #Write-Host "*************************************"
+        echo "Palo Alto Wildfire Results" >> "$caseFolder$caseID\spam-report.txt"
+        echo "Submitted file: $fileName" >> "$caseFolder$caseID\spam-report.txt"
+        echo "Submitted hash: $fileHash" >> "$caseFolder$caseID\spam-report.txt"
+        echo "Wildfire Malware Verdict: $wfMalware" >> "$caseFolder$caseID\spam-report.txt"
+        echo "Wildfire returned hashes: MD5 $wfFileMd5 SHA256 $wfFileSha256" >> "$caseFolder$caseID\spam-report.txt"
+        echo "Wildfire Reported File Size: $wfFileSize" >> "$caseFolder$caseID\spam-report.txt"
+        echo "Wildfire Reported File Type: $wfFiletype" >> "$caseFolder$caseID\spam-report.txt"
+
     }
 
 }
-
-#Not working
-<#
-if ( $checkLink ) {
-    Write-Host $checkLink
-    $payload = "------WebKitFormBoundary7MA4YWxkTrZu0gW\r\nContent-Disposition: form-data; name=`"apikey`"\r\n\r\$key\r\n------WebKitFormBoundary7MA4YWxkTrZu0gW\r\nContent-Disposition: form-data; name=`"link`"\r\n\r\$checkLink\r\n------WebKitFormBoundary7MA4YWxkTrZu0gW\r\nContent-Disposition: form-data; name=\`format\`\r\n\r\nxml\r\n------WebKitFormBoundary7MA4YWxkTrZu0gW--"
-    Write-Host $payload
-    $wfQuery2 = Invoke-WebRequest -uri "https://wildfire.paloaltonetworks.com/publicapi/submit/link" -Method Post -Body $payload
-
-}
-#>
-
-
-
-#Old code
-
-<#
-$shodanIPQuery | Where-Object -Property $link -Match $IPregex
-$shodanIP = $Matches.Address
-$shodanLink = "https://www.shodan.io/host/$shodanIP"
-
-# Query Shodan Host scan
-$shodanHostInfo = Invoke-RestMethod "https://api.shodan.io/shodan/host/$shodanIP`?key=$key"
-$shodanScanDate = $shodanHostInfo.last_update
-$shodanCountry = $shodanHostInfo.country_name
-$shodanRegion = $shodanHostInfo.region_code
-$shodanCity = $shodanHostInfo.city
-$shodanPostal = $shodanHostInfo.postal_code
-$shodanPorts = $shodanHostInfo.ports
-$shodanTags = $shodanHostInfo.tags
-
-echo "Host Information: $shodanHostInfo" >> "$caseFolder$caseID\spam-report.txt"
-echo "Scan Date: $shodanScanDate" >> "$caseFolder$caseID\spam-report.txt"
-echo "Country: $shodanCountry" >> "$caseFolder$caseID\spam-report.txt"
-echo "Region: $shodanRegion" >> "$caseFolder$caseID\spam-report.txt"
-echo "City: $shodanCity" >> "$caseFolder$caseID\spam-report.txt"
-echo "Postal Code: $shodanPostal" >> "$caseFolder$caseID\spam-report.txt"
-echo "Ports: $shodanPorts" >> "$caseFolder$caseID\spam-report.txt"
-echo "Tags: $shodanTags" >> "$caseFolder$caseID\spam-report.txt"
-
-#Determine if HTTPS services identified.
-$shodanModules = $shodanHostInfo.data | Select-Object -ExpandProperty _shodan | Select-Object -ExpandProperty module
-
-#If HTTPS identified populate associated variables.
-if ( $shodanModules -imatch "https" ) {
-    $shodanSSL = $true
-    $shodanCert1 = $shodanHostInfo.data | Select-Object -ExpandProperty ssl
-    $shodanCertIssuer = $shodanCert1.cert.issuer.CN
-    $shodanCertExpiration = $shodanCert1.cert.expires
-
-    echo $shodanCert1 > "$caseFolder$caseID\Link-$link-Certificate.txt"
-       
-} else {
-
-    Write-Host "Scanned host does not run any HTTPS services."
-    $shodanSSL = $false
-    $shodanCert1 = $null
-    $shodanCertIssuer = $null
-    $shodanCertExpiration = $null
-}
-
-if ( $shodanCert1.cert.expired -eq $true ) {
-    $shodanStatus = "EXPIRED CERTIFICATE! Shodan has reported $link has expired certificates. Last scanned on $shodanScanDate.  Full details available here: $shodanLink."
-    Write-Host $shodanStatus
-    $threatScore += 1
-
-    & $pieFolder\plugins\Case-API.ps1 -lrhost $LogRhythmHost -casenum $caseNumber -updateCase "$shodanStatus" -token $caseAPItoken
-    echo $shodanStatus >> "$caseFolder$caseID\spam-report.txt"
-} 
-
-if ( $shodanCertIssuer -imatch "Let's Encrypt" ) {
-    $shodanStatus = "RISKY CERTIFICATE AUTHORITY DETECTED! Shodan has reported $link CA as Let's Encrypt. Full details available here: $shodanLink."
-    Write-Host $shodanStatus
-    $threatScore += 1
-
-    & $pieFolder\plugins\Case-API.ps1 -lrhost $LogRhythmHost -casenum $caseNumber -updateCase "$shodanStatus" -token $caseAPItoken
-    echo $shodanStatus >> "$caseFolder$caseID\spam-report.txt"                       
-} elseif ( $shodanTags -imatch "self-signed" ) {
-    $shodanStatus = "SELF SIGNED CERTIFICATE DETECTED! Shodan has reported $link certificates as self-signed. Full details available here: $shodanLink."
-    Write-Host $shodanStatus
-    $threatScore += 1
-
-    & $pieFolder\plugins\Case-API.ps1 -lrhost $LogRhythmHost -casenum $caseNumber -updateCase "$shodanStatus" -token $caseAPItoken  
-    echo $shodanStatus >> "$caseFolder$caseID\spam-report.txt"     
-}
-
-if ( $shodanDetails -eq $true ) {
-    $shodanStatus = "====INFO - SHODAN====\r\nInformation on $link`:$shodanIP.\r\nReported location:\r\n Country: $shodanCountry"
-    if ( $shodanCity ) { $shodanStatus += "\r\n City: $shodanCity" } 
-    if ( $shodanRegion ) { $shodanStatus += "\r\n Region: $shodanRegion" }
-    if ( $shodanPostal ) { $shodanStatus += "\r\n Postal: $shodanPostal" }
-    if ( $shodanSSL -eq $true ) { $shodanStatus += "\r\nCertificate Authority: $shodanCertIssuer.\r\nExpires on: $shodanCertExpiration" }
-    if ( $shodanTags ) { $shodanStatus += "\r\nDetected tags: $shodanTags" }
-    $shodanStatus += "\r\nLast scanned on $shodanScanDate."
-
-    & $pieFolder\plugins\Case-API.ps1 -lrhost $LogRhythmHost -casenum $caseNumber -updateCase "$shodanStatus" -token $caseAPItoken
-
-}
-        
-if ( $threatScore -le 0 ) { 
-    $shodanStatus = "Shodan has determined $link is clean. Full details available here: $shodanLink."
-    echo $shodanStatus >> "$caseFolder$caseID\spam-report.txt"
-    Write-Host $shodanStatus
-    & $pieFolder\plugins\Case-API.ps1 -lrhost $LogRhythmHost -casenum $caseNumber -updateCase "$shodanStatus" -token $caseAPItoken
-}
-#>

--- a/Scripts/PIE_Message-Trace-Logging/plugins/Wildfire.ps1
+++ b/Scripts/PIE_Message-Trace-Logging/plugins/Wildfire.ps1
@@ -75,8 +75,8 @@ if ( $fileHash ) {
             echo "Wildfire Verdict: Hash not found within Wildfire database" >> "$caseFolder$caseID\spam-report.txt"
         }
         -101{
-            #-101 Error occured with Palo Alto Wildfire API
-            Write-Verbose "An error occured within the Wildfire API." 
+            #-101 Error occurred with Palo Alto Wildfire API
+            Write-Verbose "An error occurred within the Wildfire API." 
 
             $wfStatus = "====ERROR - WILDFIRE====\r\nWildfire has encountered an API error.\r\n\r\nWildfire Information:\r\n File Name: $fileName\r\n File SHA256: $fileHash\r\n\r\nRe-check file status at later time."
             
@@ -101,17 +101,17 @@ if ( $fileHash ) {
             echo "Wildfire Verdict: Status Pending" >> "$caseFolder$caseID\spam-report.txt"
         }
         0{
-            #0 FIle identified as bening
-            Write-Verbose "Submitted hash value is confirmed bening."
+            #0 FIle identified as benign
+            Write-Verbose "Submitted hash value is confirmed benign."
             
-            $wfStatus = "====INFO - WILDFIRE====\r\nWildfire has reported $fileName as bening.\r\n\r\nWildfire Information:\r\n File Name: $fileName\r\n File SHA256: $fileHash"
+            $wfStatus = "====INFO - WILDFIRE====\r\nWildfire has reported $fileName as benign.\r\n\r\nWildfire Information:\r\n File Name: $fileName\r\n File SHA256: $fileHash"
             
             & $pieFolder\plugins\Case-API.ps1 -lrhost $LogRhythmHost -casenum $caseNumber -updateCase "$wfStatus" -token $caseAPItoken
 
             echo "Palo Alto Wildfire Results" >> "$caseFolder$caseID\spam-report.txt"
             echo "Submitted file: $fileName" >> "$caseFolder$caseID\spam-report.txt"
             echo "Submitted hash: $fileHash" >> "$caseFolder$caseID\spam-report.txt"
-            echo "Wildfire Verdict: File Bening" >> "$caseFolder$caseID\spam-report.txt"
+            echo "Wildfire Verdict: File Benign" >> "$caseFolder$caseID\spam-report.txt"
         }
         1{
             #1 File identified as malware
@@ -122,17 +122,17 @@ if ( $fileHash ) {
             Write-Verbose "Submitted hash value is confirmed as grayware."
         }
         default{
-            #Unknown error occured
-            Write-Verbose "An unknown error has occured within Wildfire.ps1."
+            #Unknown error occurred
+            Write-Verbose "An unknown error has occurred within Wildfire.ps1."
             
-            $wfStatus = "====ERROR - WILDFIRE SCRIPT====\r\nAn unknown error has occured.\r\n\r\nWildfire Information:\r\n File Name: $fileName\r\n File SHA256: $fileHash\r\n\r\nPlease check the hash format and manually submit at: https://wildfire.paloaltonetworks.com/."
+            $wfStatus = "====ERROR - WILDFIRE SCRIPT====\r\nAn unknown error has occurred.\r\n\r\nWildfire Information:\r\n File Name: $fileName\r\n File SHA256: $fileHash\r\n\r\nPlease check the hash format and manually submit at: https://wildfire.paloaltonetworks.com/."
             
             & $pieFolder\plugins\Case-API.ps1 -lrhost $LogRhythmHost -casenum $caseNumber -updateCase "$wfStatus" -token $caseAPItoken
 
             echo "Palo Alto Wildfire Results" >> "$caseFolder$caseID\spam-report.txt"
             echo "Submitted file: $fileName" >> "$caseFolder$caseID\spam-report.txt"
             echo "Submitted hash: $fileHash" >> "$caseFolder$caseID\spam-report.txt"
-            echo "Wildfire Verdict: An unspecified error has occured" >> "$caseFolder$caseID\spam-report.txt"
+            echo "Wildfire Verdict: An unspecified error has occurred" >> "$caseFolder$caseID\spam-report.txt"
         }
     }
     if ( $wfVerdict -eq "1" -or $wfVerdict -eq "2" ) {

--- a/Scripts/PIE_Message-Trace-Logging/plugins/Wildfire.ps1
+++ b/Scripts/PIE_Message-Trace-Logging/plugins/Wildfire.ps1
@@ -1,0 +1,168 @@
+#
+# Author: JTekt
+# August 2018
+# Version: 0.1
+#
+# Early development of Shodan integration for PIE.  Exploritory to identify potential areas of evidence collection and risk assessment acceleration.
+#   
+# Goals:
+# <In Progress> - Send MD5 or SHA256 hash to Wildfire API for results.  If results show malicious, return details.
+# <In Progress> - Send bulk MD5 or SHA256 - Will reduce number of API calls to support large installations.
+# <Not Started> - URL inspection.
+# <Not Started> - PIE ingestion.
+#
+
+# .\Wildfire.ps1 -key $wildfireAPI -link $link -file $file -caseID $caseID -caseFolder $caseFolder -pieFolder $pieFolder -logRhythmHost $logRhythmHost -caseAPItoken $caseAPItoken
+
+[CmdLetBinding()]
+param( 
+    [string]$key,
+    [string]$link,
+    [string]$file,
+    [string]$caseID,
+    [string]$caseFolder,
+    [string]$pieFolder,
+    [string]$LogRhythmHost,
+    [string]$caseAPItoken
+)
+#Temp Variables
+$key = ''
+$hash = "dca86121cc7427e375fd24fe5871d727"
+$hash2 = "C:\hashlist.txt"
+$tmpFolder = ".\"
+
+
+
+
+# Mask errors
+$ErrorActionPreference= 'continue'
+
+# Global Parameters
+$IPregex='(?<Address>((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))'
+
+# Query DNS and obtain domain IP address
+#Get verdict - single lookup - Simple lookup
+$wfQuery = Invoke-WebRequest -uri "https://wildfire.paloaltonetworks.com/publicapi/get/verdict" -Method Post -Body "apikey=$key;hash=$hash;format=xml"
+#Get verdict - bulk lookup - Simple lookup
+#$wfQuery = Invoke-WebRequest -uri "https://wildfire.paloaltonetworks.com/publicapi/get/verdicts" -Method Post -Body "apikey=$key;file=$hash2"
+<#Verdict details
+The verdict element value can be one of the following:
+0 : benign
+1 : malware
+2 : grayware
+-100 : pending, the sample exists, but there is currently no verdict
+-101 : error
+-102 : unknown, cannot find sample record in the database
+-103 : invalid hash value
+
+If return code is 102, submit file for evaluation.
+#>
+
+#Get report - IE detailed lookup
+#$wfQuery = Invoke-WebRequest -uri "https://wildfire.paloaltonetworks.com/publicapi/get/report" -Method Post -Body "apikey=$key;hash=$hash;format=xml"
+$wfQuery.RawContent | Out-File $tmpFolder\wfAnalysis.txt
+[xml]$wfResults = Get-Content $tmpFolder\wfAnalysis.txt | select -Skip 7
+#### Are there results?!####
+## If yes, proceed to evaluate
+## If no, upload file
+Write-Host "====================================="
+Write-Host $wfResults.wildfire.file_info.malware
+$wfMalware = $wfResults.wildfire.file_info.malware
+$wfFiletype = $wfResults.wildfire.file_info.filetype
+$wfFileMd5 = $wfResults.wildfire.file_info.md5
+$wfFileSha256 = $wfResults.wildfire.file_info.sha256
+$wfFileSize = $wfResults.wildfire.file_info.size
+Write-Host "Wildfire record for $hash.  Is it malware: $wfMalware File Type: $wfFiletype File Size: $wfFileSize MD5: $wfFileMd5  SHA256: $wfFileSha256"
+Write-Host "*************************************"
+
+
+<#
+$shodanIPQuery | Where-Object -Property $link -Match $IPregex
+$shodanIP = $Matches.Address
+$shodanLink = "https://www.shodan.io/host/$shodanIP"
+
+# Query Shodan Host scan
+$shodanHostInfo = Invoke-RestMethod "https://api.shodan.io/shodan/host/$shodanIP`?key=$key"
+$shodanScanDate = $shodanHostInfo.last_update
+$shodanCountry = $shodanHostInfo.country_name
+$shodanRegion = $shodanHostInfo.region_code
+$shodanCity = $shodanHostInfo.city
+$shodanPostal = $shodanHostInfo.postal_code
+$shodanPorts = $shodanHostInfo.ports
+$shodanTags = $shodanHostInfo.tags
+
+echo "Host Information: $shodanHostInfo" >> "$caseFolder$caseID\spam-report.txt"
+echo "Scan Date: $shodanScanDate" >> "$caseFolder$caseID\spam-report.txt"
+echo "Country: $shodanCountry" >> "$caseFolder$caseID\spam-report.txt"
+echo "Region: $shodanRegion" >> "$caseFolder$caseID\spam-report.txt"
+echo "City: $shodanCity" >> "$caseFolder$caseID\spam-report.txt"
+echo "Postal Code: $shodanPostal" >> "$caseFolder$caseID\spam-report.txt"
+echo "Ports: $shodanPorts" >> "$caseFolder$caseID\spam-report.txt"
+echo "Tags: $shodanTags" >> "$caseFolder$caseID\spam-report.txt"
+
+#Determine if HTTPS services identified.
+$shodanModules = $shodanHostInfo.data | Select-Object -ExpandProperty _shodan | Select-Object -ExpandProperty module
+
+#If HTTPS identified populate associated variables.
+if ( $shodanModules -imatch "https" ) {
+    $shodanSSL = $true
+    $shodanCert1 = $shodanHostInfo.data | Select-Object -ExpandProperty ssl
+    $shodanCertIssuer = $shodanCert1.cert.issuer.CN
+    $shodanCertExpiration = $shodanCert1.cert.expires
+
+    echo $shodanCert1 > "$caseFolder$caseID\Link-$link-Certificate.txt"
+       
+} else {
+
+    Write-Host "Scanned host does not run any HTTPS services."
+    $shodanSSL = $false
+    $shodanCert1 = $null
+    $shodanCertIssuer = $null
+    $shodanCertExpiration = $null
+}
+
+if ( $shodanCert1.cert.expired -eq $true ) {
+    $shodanStatus = "EXPIRED CERTIFICATE! Shodan has reported $link has expired certificates. Last scanned on $shodanScanDate.  Full details available here: $shodanLink."
+    Write-Host $shodanStatus
+    $threatScore += 1
+
+    & $pieFolder\plugins\Case-API.ps1 -lrhost $LogRhythmHost -casenum $caseNumber -updateCase "$shodanStatus" -token $caseAPItoken
+    echo $shodanStatus >> "$caseFolder$caseID\spam-report.txt"
+} 
+
+if ( $shodanCertIssuer -imatch "Let's Encrypt" ) {
+    $shodanStatus = "RISKY CERTIFICATE AUTHORITY DETECTED! Shodan has reported $link CA as Let's Encrypt. Full details available here: $shodanLink."
+    Write-Host $shodanStatus
+    $threatScore += 1
+
+    & $pieFolder\plugins\Case-API.ps1 -lrhost $LogRhythmHost -casenum $caseNumber -updateCase "$shodanStatus" -token $caseAPItoken
+    echo $shodanStatus >> "$caseFolder$caseID\spam-report.txt"                       
+} elseif ( $shodanTags -imatch "self-signed" ) {
+    $shodanStatus = "SELF SIGNED CERTIFICATE DETECTED! Shodan has reported $link certificates as self-signed. Full details available here: $shodanLink."
+    Write-Host $shodanStatus
+    $threatScore += 1
+
+    & $pieFolder\plugins\Case-API.ps1 -lrhost $LogRhythmHost -casenum $caseNumber -updateCase "$shodanStatus" -token $caseAPItoken  
+    echo $shodanStatus >> "$caseFolder$caseID\spam-report.txt"     
+}
+
+if ( $shodanDetails -eq $true ) {
+    $shodanStatus = "====INFO - SHODAN====\r\nInformation on $link`:$shodanIP.\r\nReported location:\r\n Country: $shodanCountry"
+    if ( $shodanCity ) { $shodanStatus += "\r\n City: $shodanCity" } 
+    if ( $shodanRegion ) { $shodanStatus += "\r\n Region: $shodanRegion" }
+    if ( $shodanPostal ) { $shodanStatus += "\r\n Postal: $shodanPostal" }
+    if ( $shodanSSL -eq $true ) { $shodanStatus += "\r\nCertificate Authority: $shodanCertIssuer.\r\nExpires on: $shodanCertExpiration" }
+    if ( $shodanTags ) { $shodanStatus += "\r\nDetected tags: $shodanTags" }
+    $shodanStatus += "\r\nLast scanned on $shodanScanDate."
+
+    & $pieFolder\plugins\Case-API.ps1 -lrhost $LogRhythmHost -casenum $caseNumber -updateCase "$shodanStatus" -token $caseAPItoken
+
+}
+        
+if ( $threatScore -le 0 ) { 
+    $shodanStatus = "Shodan has determined $link is clean. Full details available here: $shodanLink."
+    echo $shodanStatus >> "$caseFolder$caseID\spam-report.txt"
+    Write-Host $shodanStatus
+    & $pieFolder\plugins\Case-API.ps1 -lrhost $LogRhythmHost -casenum $caseNumber -updateCase "$shodanStatus" -token $caseAPItoken
+}
+#>


### PR DESCRIPTION
Added in Palo Alto Wildfire plugin support:
This plugin currently examines files by submitting SHA256 hashes of e-mail attachments to the Palo Alto Wildfire API to determine if the hash is present in the Wildfire database.  If the file is in the database and is known Malicious or Grayware additional details are retrieved and populated in PIE case record and submitted to LogRhythm Case API.

[Wildfire LR Case Example](https://imgur.com/Z1u1XAa)

[Wildfire Spam Report Example](https://imgur.com/hghhbwQ)

Shodan.io update:
Cleaned up Invoke-O365Trace.ps1's call of Shodan plugin when set to true.  Will no longer populate Shodan header/footer into spam-report.txt when no links were identified within the e-mail.
